### PR TITLE
no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.34.2", stable, beta, nightly]
-        features: ["default", "alloc"]
+        # alloc crate requires Rust 1.36
+        rust: ["1.36", stable, beta, nightly]
+        features: ["default", "num-traits"]
     steps:
     - uses: actions/checkout@v2
     - run: rustup default ${{ matrix.rust }}
@@ -18,7 +19,7 @@ jobs:
       run: >
         cargo build --no-default-features --features=${{ matrix.features }} --verbose
     - name: test
-      if: ${{ matrix.rust != '1.34.2' }}
+      if: ${{ matrix.rust != '1.36' }}
       run: >
         cargo test --no-default-features --features=${{ matrix.features }} --tests --benches
       # TODO: add criterion benchmarks?
@@ -36,3 +37,15 @@ jobs:
       with:
         command: fmt
         args: -- --check
+
+  no_std_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - name: build
+      run: >
+         cargo no-std-check --no-default-features --features=num-traits

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # alloc crate requires Rust 1.36
-        rust: ["1.36", stable, beta, nightly]
+        rust: ["1.56", stable, beta, nightly]
         features: ["default", "num-traits"]
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,6 @@ jobs:
       run: >
         cargo build --no-default-features --features=${{ matrix.features }} --verbose
     - name: test
-      if: ${{ matrix.rust != '1.36' }}
       run: >
         cargo test --no-default-features --features=${{ matrix.features }} --tests --benches
       # TODO: add criterion benchmarks?

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,5 +46,6 @@ jobs:
         toolchain: nightly
         override: true
     - name: build
-      run: >
-         cargo no-std-check --no-default-features --features=num-traits
+      run: |
+        cargo install cargo-no-std-check
+        cargo no-std-check --no-default-features --features=num-traits

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,17 +10,17 @@ jobs:
     strategy:
       matrix:
         rust: ["1.34.2", stable, beta, nightly]
-        command: [build, test]
+        features: ["default", "alloc"]
     steps:
     - uses: actions/checkout@v2
     - run: rustup default ${{ matrix.rust }}
     - name: build
       run: >
-        cargo build --verbose
+        cargo build --no-default-features --features=${{ matrix.features }} --verbose
     - name: test
       if: ${{ matrix.rust != '1.34.2' }}
       run: >
-        cargo test --tests --benches
+        cargo test --no-default-features --features=${{ matrix.features }} --tests --benches
       # TODO: add criterion benchmarks?
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 # NOTE: 2018 is needed else "maybe a missing crate `core`"
-edition = "2018"
+edition = "2021"
 name = "color_quant"
 license = "MIT"
 version = "1.1.0"
@@ -8,6 +8,7 @@ authors = ["nwin <nwin@users.noreply.github.com>"]
 readme = "README.md"
 description = "Color quantization library to reduce n colors to 256 colors."
 repository = "https://github.com/image-rs/color_quant.git"
+rust-version = "1.56"
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2021"
 name = "color_quant"
 license = "MIT"
 version = "1.1.0"
@@ -6,3 +7,7 @@ authors = ["nwin <nwin@users.noreply.github.com>"]
 readme = "README.md"
 description = "Color quantization library to reduce n colors to 256 colors."
 repository = "https://github.com/image-rs/color_quant.git"
+
+[dependencies]
+# libm: "Uncomment if you wish to use `Float` and `Real` without `std`"
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-edition = "2021"
+# NOTE: 2018 is needed else "maybe a missing crate `core`"
+edition = "2018"
 name = "color_quant"
 license = "MIT"
 version = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,7 @@ repository = "https://github.com/image-rs/color_quant.git"
 
 [dependencies]
 # libm: "Uncomment if you wish to use `Float` and `Real` without `std`"
-num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+num-traits = { version = "0.2", default-features = false }
+
+[features]
+libm = ["num-traits/libm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,9 @@ description = "Color quantization library to reduce n colors to 256 colors."
 repository = "https://github.com/image-rs/color_quant.git"
 
 [dependencies]
-num-traits = { version = "0.2", default-features = false }
+num-traits = { version = "0.2", default-features = false, optional = true }
+
+[features]
+default = ["std"]
+std = []
+alloc = ["num-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,4 @@ description = "Color quantization library to reduce n colors to 256 colors."
 repository = "https://github.com/image-rs/color_quant.git"
 
 [dependencies]
-# libm: "Uncomment if you wish to use `Float` and `Real` without `std`"
 num-traits = { version = "0.2", default-features = false }
-
-[features]
-libm = ["num-traits/libm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ num-traits = { version = "0.2", default-features = false, optional = true }
 [features]
 default = ["std"]
 std = []
-num-traits = ["dep:num-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ num-traits = { version = "0.2", default-features = false, optional = true }
 [features]
 default = ["std"]
 std = []
-alloc = ["num-traits"]
+num-traits = ["dep:num-traits"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ quantization algorithm by Anthony Dekker.
     let indixes: Vec<u8> = data.chunks(4).map(|pix| nq.index_of(pix) as u8).collect();
     let color_map = nq.color_map_rgba();
 
+#### no_std
+
+You should be able to use this crate in `no_std` environment e.g.:
+`color_quant = { version = "1.1", default-features = false, features = ['num-traits'] }`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ that this copyright notice remain intact.
 #[macro_use]
 extern crate alloc;
 
+#[cfg(not(feature = "std"))]
 #[allow(unused_imports)]
 use num_traits::float::FloatCore;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,20 @@ that this copyright notice remain intact.
 //! let color_map = nq.color_map_rgba();
 //! ```
 
+// #![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+#[allow(unused_imports)]
+use num_traits::float::FloatCore;
+
 mod math;
 use crate::math::clamp;
 
-use std::cmp::{max, min};
+use alloc::vec::Vec;
+use core::cmp::{max, min};
 
 const CHANNELS: usize = 4;
 
@@ -279,7 +289,7 @@ impl NeuQuant {
     /// for frequently chosen neurons, freq[i] is high and bias[i] is negative
     /// bias[i] = gamma*((1/self.netsize)-freq[i])
     fn contest(&mut self, b: f64, g: f64, r: f64, a: f64) -> i32 {
-        use std::f64;
+        use core::f64;
 
         let mut bestd = f64::MAX;
         let mut bestbiasd: f64 = bestd;
@@ -411,7 +421,7 @@ impl NeuQuant {
             q = self.colormap[smallpos];
             // swap p (i) and q (smallpos) entries
             if i != smallpos {
-                ::std::mem::swap(&mut p, &mut q);
+                ::core::mem::swap(&mut p, &mut q);
                 self.colormap[i] = p;
                 self.colormap[smallpos] = q;
             }
@@ -433,7 +443,7 @@ impl NeuQuant {
     }
     /// Search for best matching color
     fn search_netindex(&self, b: u8, g: u8, r: u8, a: u8) -> usize {
-        let mut best_dist = std::i32::MAX;
+        let mut best_dist = core::i32::MAX;
         let first_guess = self.netindex[g as usize];
         let mut best_pos = first_guess;
         let mut i = best_pos;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ that this copyright notice remain intact.
 #[macro_use]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(feature = "num-traits", not(feature = "std")))]
 #[allow(unused_imports)]
 use num_traits::float::FloatCore;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@ that this copyright notice remain intact.
 //! let color_map = nq.color_map_rgba();
 //! ```
 
-// #![no_std]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]


### PR DESCRIPTION
Hello,

I am currently in the process of porting `image` and `imageproc` to work in SGX env, and I hit the issue of this crate using `std`.

So I am opening the PR to see if this could interest you.
And if so, I could clean up the commits, and/or rewrite them a bit more cleanly.